### PR TITLE
Create traits for pretty/canonical serialization

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -51,6 +51,10 @@ doc/CODE_OF_CONDUCT.md: complete
 doc/BUILDING.md: complete
 Complete all planned code reorganization/renaming
 docs/implementation guide/References: complete
+a trait for fn to_canonical_json()
+many to_stdiowrite() methods have common code that could be factored into a common function
+a trait for types that have to_stdiowrite()
+a trait for types that have to_stdiowrite() and perhaps _pretty() and _canonical() variants
 
 ====^^^^====^^^^====^^^^====^^^^====^^^^==== DONE merged to main ====^^^^====^^^^====^^^^====^^^^====^^^^====
 
@@ -70,8 +74,6 @@ serialize format wrapped in version
 ensure SecretCoefficient is serialized in a fixed-length format
 
 Election parameters: add a type field initally set to 'HomomorphicTallying'
-
-a trait for fn to_canonical_json()
 
 [Security: out of scope] TOCTOU bug with --insecure-deterministic flag electionguard.exe main.rs. Should be fixed, but in practice if that filesystem is writable by a malicious party then you likely have much, much bigger concerns.
 
@@ -146,10 +148,6 @@ open issues for any remaining TODO items for 1.0
 BallotDefinition doc for write-in option
 
 would be nice to support a PartySelection type vote, rather than rely on the vendor to give us the correct selections explicitly
-
-many to_stdiowrite() methods have common code that could be factored into a common function
-a trait for types that have to_stdiowrite()
-a trait for types that have to_stdiowrite() and perhaps _pretty() and _canonical() variants
 
 a trait for types that have pub fn validate(&Self)
 a trait for types that have pub fn validate(&Self, &ElectionParameters)

--- a/src/eg/src/ballot.rs
+++ b/src/eg/src/ballot.rs
@@ -5,7 +5,7 @@
 #![deny(clippy::panic)]
 #![deny(clippy::manual_assert)]
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/src/eg/src/ballot.rs
+++ b/src/eg/src/ballot.rs
@@ -22,7 +22,7 @@ use crate::{
     election_record::PreVotingData,
     fixed_parameters::FixedParameters,
     hash::HValue,
-    serialize::SerializablePretty,
+    serializable::SerializablePretty,
     joint_election_public_key::Ciphertext,
     zk::ProofRangeError,
 };

--- a/src/eg/src/ballot.rs
+++ b/src/eg/src/ballot.rs
@@ -22,6 +22,7 @@ use crate::{
     election_record::PreVotingData,
     fixed_parameters::FixedParameters,
     hash::HValue,
+    serialize::SerializablePretty,
     joint_election_public_key::Ciphertext,
     zk::ProofRangeError,
 };
@@ -167,18 +168,6 @@ impl BallotEncrypted {
         true
     }
 
-    /// Writes a `BallotEncrypted` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .context("Error serializing voter selection")?;
-
-        ser.into_inner()
-            .write_all(b"\n")
-            .context("Error writing serialized voter selection to file")
-    }
-
     /// Scale a [`BallotEncrypted`] by a factor, producing a [`ScaledBallotEncrypted`].
     /// Each encrypted vote in the ballot gets scaled by the same factor.
     pub fn scale(
@@ -194,6 +183,8 @@ impl BallotEncrypted {
         ScaledBallotEncrypted { contests }
     }
 }
+
+impl SerializablePretty for BallotEncrypted {}
 
 /// This function takes an iterator over encrypted ballots and tallies up the
 /// votes on each option in each contest. The result is map from `ContestIndex`

--- a/src/eg/src/election_manifest.rs
+++ b/src/eg/src/election_manifest.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ballot_style::BallotStyle;
 use crate::index::Index;
-use crate::serialize::{SerializableCanonical, SerializablePretty};
+use crate::serializable::{SerializableCanonical, SerializablePretty};
 use crate::vec1::{HasIndexTypeMarker, Vec1};
 
 /// The election manifest.
@@ -114,7 +114,7 @@ pub mod test {
         // Pretty
         {
             let mut buf = Cursor::new(vec![0u8; 0]);
-            election_manifest.to_stdiowrite(&mut buf)?;
+            election_manifest.to_stdiowrite_pretty(&mut buf)?;
 
             let json_pretty = buf.into_inner();
             assert!(json_pretty.len() > 6);

--- a/src/eg/src/election_manifest.rs
+++ b/src/eg/src/election_manifest.rs
@@ -5,13 +5,12 @@
 #![deny(clippy::panic)]
 #![deny(clippy::manual_assert)]
 
-use std::io::Cursor;
-
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::ballot_style::BallotStyle;
 use crate::index::Index;
+use crate::serialize::{SerializableCanonical, SerializablePretty};
 use crate::vec1::{HasIndexTypeMarker, Vec1};
 
 /// The election manifest.
@@ -49,32 +48,11 @@ impl ElectionManifest {
         // We currently have no validation rules for this type.
         Ok(())
     }
-
-    /// Writes an [`ElectionManifest`] to a [`std::io::Write`] as canonical bytes.
-    /// This uses a more compact JSON format.
-    pub fn to_stdiowrite_canonical(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        serde_json::ser::to_writer(stdiowrite, self).context("Writing ElectionManifest canonical")
-    }
-
-    /// Returns the canonical byte sequence representation of the [`ElectionManifest`].
-    /// This uses a more compact JSON format.
-    pub fn to_canonical_bytes(&self) -> Result<Vec<u8>> {
-        let mut buf = Cursor::new(Vec::new());
-        self.to_stdiowrite_canonical(&mut buf)
-            .context("Writing ElectionManifest canonical")?;
-        Ok(buf.into_inner())
-    }
-
-    /// Writes an [`ElectionManifest`] to a [`std::io::Write`] as pretty JSON.
-    pub fn to_stdiowrite_pretty(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .map_err(Into::<anyhow::Error>::into)
-            .and_then(|_| ser.into_inner().write_all(b"\n").map_err(Into::into))
-            .context("Writing ElectionManifest pretty")
-    }
 }
+
+impl SerializableCanonical for ElectionManifest {}
+
+impl SerializablePretty for ElectionManifest {}
 
 /// A contest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -124,6 +102,8 @@ pub type ContestOptionIndex = Index<ContestOption>;
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 pub mod test {
+    use std::io::Cursor;
+
     use super::*;
     use crate::example_election_manifest::example_election_manifest;
 
@@ -134,7 +114,7 @@ pub mod test {
         // Pretty
         {
             let mut buf = Cursor::new(vec![0u8; 0]);
-            election_manifest.to_stdiowrite_pretty(&mut buf)?;
+            election_manifest.to_stdiowrite(&mut buf)?;
 
             let json_pretty = buf.into_inner();
             assert!(json_pretty.len() > 6);

--- a/src/eg/src/election_parameters.rs
+++ b/src/eg/src/election_parameters.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use util::csprng::Csprng;
 
 use crate::{
-    fixed_parameters::FixedParameters, serialize::SerializablePretty,
+    fixed_parameters::FixedParameters, serializable::SerializablePretty,
     varying_parameters::VaryingParameters,
 };
 

--- a/src/eg/src/election_parameters.rs
+++ b/src/eg/src/election_parameters.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 
 use util::csprng::Csprng;
 
-use crate::{fixed_parameters::FixedParameters, varying_parameters::VaryingParameters};
+use crate::{
+    fixed_parameters::FixedParameters, serialize::SerializablePretty,
+    varying_parameters::VaryingParameters,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ElectionParameters {
@@ -46,24 +49,6 @@ impl ElectionParameters {
     pub fn from_bytes(bytes: &[u8]) -> Result<ElectionParameters> {
         serde_json::from_slice(bytes).with_context(|| "Error parsing ElectionParameters bytes")
     }
-
-    /// Returns a pretty JSON `String` representation of the `ElectionParameters`.
-    /// The final line will end with a newline.
-    pub fn to_json_pretty(&self) -> String {
-        // `unwrap()` is justified here because why would JSON serialization fail?
-        #[allow(clippy::unwrap_used)]
-        let mut s = serde_json::to_string_pretty(self).unwrap();
-        s.push('\n');
-        s
-    }
-
-    /// Writes a `ElectionParameters` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .map_err(Into::<anyhow::Error>::into)
-            .and_then(|_| ser.into_inner().write_all(b"\n").map_err(Into::into))
-            .context("Writing ElectionParameters")
-    }
 }
+
+impl SerializablePretty for ElectionParameters {}

--- a/src/eg/src/election_record.rs
+++ b/src/eg/src/election_record.rs
@@ -7,19 +7,23 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use util::algebra::FieldElement;
 
 use crate::{
     ballot::BallotEncrypted,
+   
     election_manifest::{ContestIndex, ElectionManifest},
     election_parameters::ElectionParameters,
     guardian_public_key::GuardianPublicKey,
+   
     hashes::Hashes,
+   
     hashes_ext::HashesExt,
     joint_election_public_key::{Ciphertext, JointElectionPublicKey},
     verifiable_decryption::VerifiableDecryption,
+    serialize::{SerializableCanonical, SerializablePretty},
 };
 
 /// The header of the election record, generated before the election begins.
@@ -130,34 +134,8 @@ impl PreVotingData {
     pub fn from_bytes(bytes: &[u8]) -> Result<PreVotingData> {
         serde_json::from_slice(bytes).map_err(|e| anyhow!("Error parsing canonical bytes: {}", e))
     }
-
-    /// Returns a pretty JSON `String` representation of the `ElectionRecordHeader`.
-    /// The final line will end with a newline.
-    pub fn to_json_pretty(&self) -> String {
-        // `unwrap()` is justified here because why would JSON serialization fail?
-        #[allow(clippy::unwrap_used)]
-        let mut s = serde_json::to_string_pretty(self).unwrap();
-        s.push('\n');
-        s
-    }
-
-    /// Returns the canonical byte sequence representation of the `ElectionRecordHeader`.
-    /// This uses a more compact JSON format.
-    pub fn to_canonical_bytes(&self) -> Vec<u8> {
-        // `unwrap()` is justified here because why would JSON serialization fail?
-        #[allow(clippy::unwrap_used)]
-        serde_json::to_vec(self).unwrap()
-    }
-
-    /// Writes a `ElectionRecordHeader` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .context("Error writing ElectionRecordHeader")?;
-
-        ser.into_inner()
-            .write_all(b"\n")
-            .context("Error writing election record header file")
-    }
 }
+
+impl SerializableCanonical for PreVotingData {}
+
+impl SerializablePretty for PreVotingData {}

--- a/src/eg/src/election_record.rs
+++ b/src/eg/src/election_record.rs
@@ -23,7 +23,7 @@ use crate::{
     hashes_ext::HashesExt,
     joint_election_public_key::{Ciphertext, JointElectionPublicKey},
     verifiable_decryption::VerifiableDecryption,
-    serialize::{SerializableCanonical, SerializablePretty},
+    serializable::{SerializableCanonical, SerializablePretty},
 };
 
 /// The header of the election record, generated before the election begins.

--- a/src/eg/src/election_record.rs
+++ b/src/eg/src/election_record.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use util::algebra::FieldElement;
 

--- a/src/eg/src/guardian_public_key.rs
+++ b/src/eg/src/guardian_public_key.rs
@@ -20,6 +20,7 @@ use crate::{
         validate_guardian_public_key_info, GuardianPublicKeyInfo, PublicKeyValidationError,
     },
     guardian_secret_key::CoefficientCommitments,
+    serialize::SerializablePretty,
 };
 
 /// The public key for a guardian.
@@ -107,16 +108,9 @@ impl GuardianPublicKey {
         Ok(self_)
     }
 
-    /// Returns a pretty JSON `String` representation of the [`GuardianPublicKey`].
-    /// The final line will end with a newline.
-    pub fn to_json(&self) -> String {
-        // `unwrap()` is justified here because why would JSON serialization fail?
-        #[allow(clippy::unwrap_used)]
-        let mut s = serde_json::to_string_pretty(self).unwrap();
-        s.push('\n');
-        s
-    }
 }
+
+impl SerializablePretty for GuardianPublicKey {}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/src/eg/src/guardian_public_key.rs
+++ b/src/eg/src/guardian_public_key.rs
@@ -20,7 +20,7 @@ use crate::{
         validate_guardian_public_key_info, GuardianPublicKeyInfo, PublicKeyValidationError,
     },
     guardian_secret_key::CoefficientCommitments,
-    serialize::SerializablePretty,
+    serializable::SerializablePretty,
 };
 
 /// The public key for a guardian.

--- a/src/eg/src/guardian_secret_key.rs
+++ b/src/eg/src/guardian_secret_key.rs
@@ -23,6 +23,7 @@ use crate::{
     guardian_public_key_info::{
         validate_guardian_public_key_info, GuardianPublicKeyInfo, PublicKeyValidationError,
     },
+    serialize::SerializablePretty,
 };
 
 /// A polynomial coefficient used to define a secret key sharing.
@@ -229,13 +230,6 @@ impl GuardianSecretKey {
         Ok(self_)
     }
 
-    /// Writes a [`GuardianSecretKey`] to a [`std::io::Write`].
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .map_err(Into::<anyhow::Error>::into)
-            .and_then(|_| ser.into_inner().write_all(b"\n").map_err(Into::into))
-            .context("Writing GuardianSecretKey")
-    }
 }
+
+impl SerializablePretty for GuardianSecretKey {}

--- a/src/eg/src/guardian_secret_key.rs
+++ b/src/eg/src/guardian_secret_key.rs
@@ -23,7 +23,7 @@ use crate::{
     guardian_public_key_info::{
         validate_guardian_public_key_info, GuardianPublicKeyInfo, PublicKeyValidationError,
     },
-    serialize::SerializablePretty,
+    serializable::SerializablePretty,
 };
 
 /// A polynomial coefficient used to define a secret key sharing.

--- a/src/eg/src/hash.rs
+++ b/src/eg/src/hash.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use util::array_ascii::ArrayAscii;
 
-use crate::serialize::SerializablePretty;
+use crate::serializable::SerializablePretty;
 
 type HmacSha256 = Hmac<sha2::Sha256>;
 

--- a/src/eg/src/hash.rs
+++ b/src/eg/src/hash.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use util::array_ascii::ArrayAscii;
 
+use crate::serialize::SerializablePretty;
+
 type HmacSha256 = Hmac<sha2::Sha256>;
 
 // "In ElectionGuard, all inputs that are used as the HMAC key, i.e. all inputs to the first
@@ -88,32 +90,11 @@ impl HValue {
         serde_json::from_reader(io_read).map_err(|e| anyhow!("Error parsing HValue: {}", e))
     }
 
-    /// Returns a pretty JSON `String` representation of the `HValue`.
-    /// The final line will end with a newline.
-    pub fn to_json(&self) -> String {
-        // `unwrap()` is justified here because why would JSON serialization fail?
-        #[allow(clippy::unwrap_used)]
-        let mut s = serde_json::to_string_pretty(self).unwrap();
-        s.push('\n');
-        s
-    }
-
     /// Reads a `HValue` from a `std::io::Write`.
     pub fn from_stdioread(stdioread: &mut dyn std::io::Read) -> Result<Self> {
         let hashes: Self = serde_json::from_reader(stdioread).context("Reading HValue")?;
 
         Ok(hashes)
-    }
-
-    /// Writes a `HValue` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser).context("Error writing HValue")?;
-
-        ser.into_inner()
-            .write_all(b"\n")
-            .context("Error writing HValue file")
     }
 
     pub fn to_string_hex_no_prefix_suffix(&self) -> String {
@@ -122,6 +103,8 @@ impl HValue {
         s[3..s.len() - 2].to_string()
     }
 }
+
+impl SerializablePretty for HValue {}
 
 impl From<HValueByteArray> for HValue {
     #[inline]

--- a/src/eg/src/hashes.rs
+++ b/src/eg/src/hashes.rs
@@ -10,6 +10,7 @@ use crate::{
     election_parameters::ElectionParameters,
     fixed_parameters::FixedParameters,
     hash::{eg_h, HValue},
+    serialize::{SerializableCanonical, SerializablePretty},
 };
 
 /// Parameter base hash (cf. Section 3.1.2 in Specs 2.0.0)
@@ -118,21 +119,13 @@ impl Hashes {
         Ok(())
     }
 
-    /// Writes a `Hashes` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .map_err(Into::<anyhow::Error>::into)
-            .and_then(|_| ser.into_inner().write_all(b"\n").map_err(Into::into))
-            .context("Writing Hashes")
-    }
-
     /// Reads `Hashes` from a `std::io::Read`.
     pub fn from_reader(io_read: &mut dyn std::io::Read) -> Result<Hashes> {
         serde_json::from_reader(io_read).map_err(|e| anyhow!("Error parsing Hashes: {}", e))
     }
 }
+
+impl SerializablePretty for Hashes {}
 
 impl std::fmt::Debug for Hashes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {

--- a/src/eg/src/hashes.rs
+++ b/src/eg/src/hashes.rs
@@ -10,7 +10,7 @@ use crate::{
     election_parameters::ElectionParameters,
     fixed_parameters::FixedParameters,
     hash::{eg_h, HValue},
-    serialize::{SerializableCanonical, SerializablePretty},
+    serializable::{SerializableCanonical, SerializablePretty},
 };
 
 /// Parameter base hash (cf. Section 3.1.2 in Specs 2.0.0)

--- a/src/eg/src/hashes_ext.rs
+++ b/src/eg/src/hashes_ext.rs
@@ -13,7 +13,7 @@ use crate::{
     hash::{eg_h, HValue},
     hashes::Hashes,
     joint_election_public_key::JointElectionPublicKey,
-    serialize::SerializablePretty,
+    serializable::SerializablePretty,
 };
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/eg/src/hashes_ext.rs
+++ b/src/eg/src/hashes_ext.rs
@@ -13,6 +13,7 @@ use crate::{
     hash::{eg_h, HValue},
     hashes::Hashes,
     joint_election_public_key::JointElectionPublicKey,
+    serialize::SerializablePretty,
 };
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,22 +57,14 @@ impl HashesExt {
         Ok(())
     }
 
-    /// Writes a `HashesExt` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .map_err(Into::<anyhow::Error>::into)
-            .and_then(|_| ser.into_inner().write_all(b"\n").map_err(Into::into))
-            .context("Writing HashesExt")
-    }
-
     /// Reads `HashesExt` from a `std::io::Read`.
     pub fn from_reader(io_read: &mut dyn std::io::Read) -> Result<HashesExt> {
         serde_json::from_reader(io_read)
             .map_err(|e| anyhow!("Error parsing JointElectionPublicKey: {}", e))
     }
 }
+
+impl SerializablePretty for HashesExt {}
 
 impl std::fmt::Display for HashesExt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {

--- a/src/eg/src/joint_election_public_key.rs
+++ b/src/eg/src/joint_election_public_key.rs
@@ -14,7 +14,7 @@ use util::algebra::{FieldElement, Group, GroupElement, ScalarField};
 
 use crate::{
     election_parameters::ElectionParameters, fixed_parameters::FixedParameters,
-    guardian_public_key::GuardianPublicKey, index::Index, serialize::SerializablePretty,
+    guardian_public_key::GuardianPublicKey, index::Index, serializable::SerializablePretty,
 };
 
 /// The joint election public key.

--- a/src/eg/src/joint_election_public_key.rs
+++ b/src/eg/src/joint_election_public_key.rs
@@ -14,7 +14,7 @@ use util::algebra::{FieldElement, Group, GroupElement, ScalarField};
 
 use crate::{
     election_parameters::ElectionParameters, fixed_parameters::FixedParameters,
-    guardian_public_key::GuardianPublicKey, index::Index,
+    guardian_public_key::GuardianPublicKey, index::Index, serialize::SerializablePretty,
 };
 
 /// The joint election public key.
@@ -185,17 +185,9 @@ impl JointElectionPublicKey {
         self.joint_election_public_key
             .to_be_bytes_left_pad(&fixed_parameters.group)
     }
-
-    /// Writes a `JointElectionPublicKey` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .map_err(Into::<anyhow::Error>::into)
-            .and_then(|_| ser.into_inner().write_all(b"\n").map_err(Into::into))
-            .context("Writing JointElectionPublicKey")
-    }
 }
+
+impl SerializablePretty for JointElectionPublicKey {}
 
 impl AsRef<GroupElement> for JointElectionPublicKey {
     #[inline]

--- a/src/eg/src/lib.rs
+++ b/src/eg/src/lib.rs
@@ -85,7 +85,7 @@ pub mod hashes_ext;
 pub mod index;
 pub mod joint_election_public_key;
 pub mod nonce;
-pub mod serialize;
+pub mod serializable;
 pub mod standard_parameters;
 pub mod varying_parameters;
 pub mod vec1;

--- a/src/eg/src/lib.rs
+++ b/src/eg/src/lib.rs
@@ -85,6 +85,7 @@ pub mod hashes_ext;
 pub mod index;
 pub mod joint_election_public_key;
 pub mod nonce;
+pub mod serialize;
 pub mod standard_parameters;
 pub mod varying_parameters;
 pub mod vec1;

--- a/src/eg/src/serialize.rs
+++ b/src/eg/src/serialize.rs
@@ -1,0 +1,53 @@
+use anyhow::{Context, Result};
+use std::io::Cursor;
+
+pub trait SerializableCanonical {
+    /// Writes an entity to a [`std::io::Write`] as canonical bytes.
+    /// This uses a more compact JSON format.
+    fn to_stdiowrite_canonical(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()>
+    where
+        Self: serde::Serialize,
+    {
+        serde_json::ser::to_writer(stdiowrite, self).context("Writing canonical")
+    }
+
+    /// Returns the canonical byte sequence representation of the entity.
+    /// This uses a more compact JSON format.
+    fn to_canonical_bytes(&self) -> Result<Vec<u8>>
+    where
+        Self: serde::Serialize,
+    {
+        let mut buf = Cursor::new(Vec::new());
+        self.to_stdiowrite_canonical(&mut buf)
+            .context("Writing canonical")?;
+        Ok(buf.into_inner())
+    }
+}
+
+pub trait SerializablePretty {
+    /// Returns a pretty JSON `String` representation of the entity.
+    /// The final line will end with a newline.
+    fn to_json_pretty(&self) -> String
+    where
+        Self: serde::Serialize,
+    {
+        // `unwrap()` is justified here because why would JSON serialization fail?
+        #[allow(clippy::unwrap_used)]
+        let mut s = serde_json::to_string_pretty(self).unwrap();
+        s.push('\n');
+        s
+    }
+
+    /// Writes an entity to a [`std::io::Write`] as pretty JSON.
+    fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()>
+    where
+        Self: serde::Serialize,
+    {
+        let mut ser = serde_json::Serializer::pretty(stdiowrite);
+
+        self.serialize(&mut ser)
+            .map_err(Into::<anyhow::Error>::into)
+            .and_then(|_| ser.into_inner().write_all(b"\n").map_err(Into::into))
+            .context("Writing pretty")
+    }
+}

--- a/src/electionguard/src/subcommands/guardian_secret_key_generate.rs
+++ b/src/electionguard/src/subcommands/guardian_secret_key_generate.rs
@@ -10,7 +10,8 @@ use std::path::PathBuf;
 use anyhow::{bail, Context, Result};
 
 use eg::{
-    guardian::GuardianIndex, guardian_secret_key::GuardianSecretKey, serialize::SerializablePretty,
+    guardian::GuardianIndex, guardian_secret_key::GuardianSecretKey,
+    serializable::SerializablePretty,
 };
 
 use crate::{
@@ -74,7 +75,7 @@ impl Subcommand for GuardianSecretKeyGenerate {
         let description = format!("secret key for guardian {} to: {}", self.i, path.display());
 
         secret_key
-            .to_stdiowrite(stdiowrite.as_mut())
+            .to_stdiowrite_pretty(stdiowrite.as_mut())
             .with_context(|| format!("Writing {description}"))?;
 
         drop(stdiowrite);

--- a/src/electionguard/src/subcommands/guardian_secret_key_generate.rs
+++ b/src/electionguard/src/subcommands/guardian_secret_key_generate.rs
@@ -9,7 +9,9 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
 
-use eg::{guardian::GuardianIndex, guardian_secret_key::GuardianSecretKey};
+use eg::{
+    guardian::GuardianIndex, guardian_secret_key::GuardianSecretKey, serialize::SerializablePretty,
+};
 
 use crate::{
     artifacts_dir::ArtifactFile, common_utils::load_election_parameters,

--- a/src/electionguard/src/subcommands/guardian_secret_key_write_public_key.rs
+++ b/src/electionguard/src/subcommands/guardian_secret_key_write_public_key.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
 
-use eg::{guardian::GuardianIndex, serialize::SerializablePretty};
+use eg::{guardian::GuardianIndex, serializable::SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile,
@@ -70,7 +70,7 @@ impl Subcommand for GuardianSecretKeyWritePublicKey {
         )?;
 
         public_key
-            .to_stdiowrite(stdiowrite.as_mut())
+            .to_stdiowrite_pretty(stdiowrite.as_mut())
             .with_context(|| {
                 format!("Writing public key for guardian {i} to: {}", path.display())
             })?;

--- a/src/electionguard/src/subcommands/guardian_secret_key_write_public_key.rs
+++ b/src/electionguard/src/subcommands/guardian_secret_key_write_public_key.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
 
-use eg::guardian::GuardianIndex;
+use eg::{guardian::GuardianIndex, serialize::SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile,

--- a/src/electionguard/src/subcommands/preencrypted_ballot_generate.rs
+++ b/src/electionguard/src/subcommands/preencrypted_ballot_generate.rs
@@ -9,7 +9,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context, Result};
 
-use eg::{ballot_style::BallotStyleIndex, device::Device, election_record::PreVotingData};
+use eg::{
+    ballot_style::BallotStyleIndex, device::Device, election_record::PreVotingData,
+    serialize::SerializablePretty,
+};
 use preencrypted::ballot_encrypting_tool::BallotEncryptingTool;
 use util::file::create_path;
 

--- a/src/electionguard/src/subcommands/preencrypted_ballot_generate.rs
+++ b/src/electionguard/src/subcommands/preencrypted_ballot_generate.rs
@@ -11,7 +11,7 @@ use anyhow::{bail, Context, Result};
 
 use eg::{
     ballot_style::BallotStyleIndex, device::Device, election_record::PreVotingData,
-    serialize::SerializablePretty,
+    serializable::SerializablePretty,
 };
 use preencrypted::ballot_encrypting_tool::BallotEncryptingTool;
 use util::file::create_path;
@@ -86,7 +86,7 @@ impl Subcommand for PreEncryptedBallotGenerate {
             .out_file_stdiowrite(&None, Some(ArtifactFile::ElectionPreVotingData))?;
 
         pv_data
-            .to_stdiowrite(bx_write.as_mut())
+            .to_stdiowrite_pretty(bx_write.as_mut())
             .with_context(|| format!("Writing record header to: {}", path.display()))?;
 
         drop(bx_write);
@@ -124,7 +124,7 @@ impl Subcommand for PreEncryptedBallotGenerate {
             )?;
 
             ballots[b_idx]
-                .to_stdiowrite(bx_write.as_mut())
+                .to_stdiowrite_pretty(bx_write.as_mut())
                 .with_context(|| format!("Writing pre-encrypted ballot to: {}", path.display()))?;
 
             eprintln!("Wrote pre-encrypted ballot to: {}", path.display());
@@ -140,7 +140,7 @@ impl Subcommand for PreEncryptedBallotGenerate {
             )?;
 
             primary_nonces[b_idx]
-                .to_stdiowrite(bx_write.as_mut())
+                .to_stdiowrite_pretty(bx_write.as_mut())
                 .with_context(|| {
                     format!("Writing pre-encrypted ballot nonce to: {}", path.display())
                 })?;

--- a/src/electionguard/src/subcommands/preencrypted_ballot_record.rs
+++ b/src/electionguard/src/subcommands/preencrypted_ballot_record.rs
@@ -9,6 +9,7 @@ use anyhow::{bail, Context, Result};
 
 use eg::{
     ballot_style::BallotStyleIndex, device::Device, election_record::PreVotingData, hash::HValue,
+    serialize::SerializablePretty,
 };
 use preencrypted::{
     ballot::{BallotPreEncrypted, VoterSelection},

--- a/src/electionguard/src/subcommands/preencrypted_ballot_record.rs
+++ b/src/electionguard/src/subcommands/preencrypted_ballot_record.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Context, Result};
 
 use eg::{
     ballot_style::BallotStyleIndex, device::Device, election_record::PreVotingData, hash::HValue,
-    serialize::SerializablePretty,
+    serializable::SerializablePretty,
 };
 use preencrypted::{
     ballot::{BallotPreEncrypted, VoterSelection},
@@ -156,7 +156,7 @@ impl Subcommand for PreEncryptedBallotRecord {
                 )?;
 
                 encrypted_ballot
-                    .to_stdiowrite(bx_write.as_mut())
+                    .to_stdiowrite_pretty(bx_write.as_mut())
                     .with_context(|| format!("Writing encrypted ballot to: {}", path.display()))?;
                 drop(bx_write);
             } else {

--- a/src/electionguard/src/subcommands/voter_write_random_selections.rs
+++ b/src/electionguard/src/subcommands/voter_write_random_selections.rs
@@ -15,6 +15,7 @@ use anyhow::{Context, Result};
 use eg::{
     ballot::BallotEncrypted, ballot_style::BallotStyleIndex, contest_selection::ContestSelection,
     device::Device, election_manifest::ContestIndex, election_record::PreVotingData,
+    serializable::SerializablePretty,
 };
 
 use crate::{
@@ -97,7 +98,7 @@ impl Subcommand for VoterWriteRandomSelection {
         )?;
 
         ballot
-            .to_stdiowrite(stdiowrite.as_mut())
+            .to_stdiowrite_pretty(stdiowrite.as_mut())
             .with_context(|| format!("Writing ballot to: {}", path.display()))?;
 
         drop(stdiowrite);

--- a/src/electionguard/src/subcommands/write_hashes.rs
+++ b/src/electionguard/src/subcommands/write_hashes.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use eg::hashes::Hashes;
+use eg::{hashes::Hashes, serialize::SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile,

--- a/src/electionguard/src/subcommands/write_hashes.rs
+++ b/src/electionguard/src/subcommands/write_hashes.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use eg::{hashes::Hashes, serialize::SerializablePretty};
+use eg::{hashes::Hashes, serializable::SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile,
@@ -56,7 +56,7 @@ impl Subcommand for WriteHashes {
             .out_file_stdiowrite(&self.out_file, Some(ArtifactFile::Hashes))?;
 
         hashes
-            .to_stdiowrite(stdiowrite.as_mut())
+            .to_stdiowrite_pretty(stdiowrite.as_mut())
             .with_context(|| format!("Writing hashes to: {}", path.display()))?;
 
         drop(stdiowrite);

--- a/src/electionguard/src/subcommands/write_hashes_ext.rs
+++ b/src/electionguard/src/subcommands/write_hashes_ext.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use eg::hashes_ext::HashesExt;
+use eg::{hashes_ext::HashesExt, serialize::SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile,

--- a/src/electionguard/src/subcommands/write_hashes_ext.rs
+++ b/src/electionguard/src/subcommands/write_hashes_ext.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use eg::{hashes_ext::HashesExt, serialize::SerializablePretty};
+use eg::{hashes_ext::HashesExt, serializable::SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile,
@@ -54,7 +54,7 @@ impl Subcommand for WriteHashesExt {
             .out_file_stdiowrite(&self.out_file, Some(ArtifactFile::HashesExt))?;
 
         hashes_ext
-            .to_stdiowrite(stdiowrite.as_mut())
+            .to_stdiowrite_pretty(stdiowrite.as_mut())
             .with_context(|| format!("Writing hashes ext to: {}", path.display()))?;
 
         drop(stdiowrite);

--- a/src/electionguard/src/subcommands/write_joint_election_public_key.rs
+++ b/src/electionguard/src/subcommands/write_joint_election_public_key.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use eg::joint_election_public_key::JointElectionPublicKey;
+use eg::{joint_election_public_key::JointElectionPublicKey, serialize::SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile,

--- a/src/electionguard/src/subcommands/write_joint_election_public_key.rs
+++ b/src/electionguard/src/subcommands/write_joint_election_public_key.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use eg::{joint_election_public_key::JointElectionPublicKey, serialize::SerializablePretty};
+use eg::{joint_election_public_key::JointElectionPublicKey, serializable::SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile,
@@ -53,7 +53,7 @@ impl Subcommand for WriteJointElectionPublicKey {
             .out_file_stdiowrite(&self.out_file, Some(ArtifactFile::JointElectionPublicKey))?;
 
         joint_election_public_key
-            .to_stdiowrite(stdiowrite.as_mut())
+            .to_stdiowrite_pretty(stdiowrite.as_mut())
             .with_context(|| format!("Writing joint election public key to: {}", path.display()))?;
 
         drop(stdiowrite);

--- a/src/electionguard/src/subcommands/write_manifest.rs
+++ b/src/electionguard/src/subcommands/write_manifest.rs
@@ -8,6 +8,7 @@
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
+use eg::serialize::{SerializableCanonical, SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile, common_utils::ElectionManifestSource,
@@ -92,7 +93,7 @@ impl Subcommand for WriteManifest {
 
         let write_result = match self.out_format {
             Canonical => election_manifest.to_stdiowrite_canonical(&mut stdiowrite),
-            Pretty => election_manifest.to_stdiowrite_pretty(&mut stdiowrite),
+            Pretty => election_manifest.to_stdiowrite(&mut stdiowrite),
         };
 
         write_result.with_context(|| {

--- a/src/electionguard/src/subcommands/write_manifest.rs
+++ b/src/electionguard/src/subcommands/write_manifest.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
-use eg::serialize::{SerializableCanonical, SerializablePretty};
+use eg::serializable::{SerializableCanonical, SerializablePretty};
 
 use crate::{
     artifacts_dir::ArtifactFile, common_utils::ElectionManifestSource,
@@ -93,7 +93,7 @@ impl Subcommand for WriteManifest {
 
         let write_result = match self.out_format {
             Canonical => election_manifest.to_stdiowrite_canonical(&mut stdiowrite),
-            Pretty => election_manifest.to_stdiowrite(&mut stdiowrite),
+            Pretty => election_manifest.to_stdiowrite_pretty(&mut stdiowrite),
         };
 
         write_result.with_context(|| {

--- a/src/electionguard/src/subcommands/write_parameters.rs
+++ b/src/electionguard/src/subcommands/write_parameters.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use eg::{
     election_parameters::ElectionParameters, guardian::GuardianIndex,
-    serialize::SerializablePretty, standard_parameters::STANDARD_PARAMETERS,
+    serializable::SerializablePretty, standard_parameters::STANDARD_PARAMETERS,
     varying_parameters::VaryingParameters,
 };
 
@@ -95,7 +95,7 @@ impl Subcommand for WriteParameters {
             .out_file_stdiowrite(&self.out_file, Some(ArtifactFile::ElectionParameters))?;
 
         election_parameters
-            .to_stdiowrite(stdiowrite.as_mut())
+            .to_stdiowrite_pretty(stdiowrite.as_mut())
             .with_context(|| format!("Writing election parameters to: {}", path.display()))?;
 
         drop(stdiowrite);

--- a/src/electionguard/src/subcommands/write_parameters.rs
+++ b/src/electionguard/src/subcommands/write_parameters.rs
@@ -12,7 +12,8 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use eg::{
     election_parameters::ElectionParameters, guardian::GuardianIndex,
-    standard_parameters::STANDARD_PARAMETERS, varying_parameters::VaryingParameters,
+    serialize::SerializablePretty, standard_parameters::STANDARD_PARAMETERS,
+    varying_parameters::VaryingParameters,
 };
 
 use crate::{

--- a/src/preencrypted/src/ballot.rs
+++ b/src/preencrypted/src/ballot.rs
@@ -17,7 +17,7 @@ use eg::{
     election_manifest::{ContestIndex, ElectionManifest},
     election_record::PreVotingData,
     hash::HValue,
-    serialize::SerializablePretty,
+    serializable::SerializablePretty,
     vec1::Vec1,
 };
 use serde::{Deserialize, Serialize};

--- a/src/preencrypted/src/ballot.rs
+++ b/src/preencrypted/src/ballot.rs
@@ -17,6 +17,7 @@ use eg::{
     election_manifest::{ContestIndex, ElectionManifest},
     election_record::PreVotingData,
     hash::HValue,
+    serialize::SerializablePretty,
     vec1::Vec1,
 };
 use serde::{Deserialize, Serialize};
@@ -81,19 +82,9 @@ impl VoterSelection {
 
         Ok(selection)
     }
-
-    /// Writes a `VoterSelection` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .context("Error serializing voter selection")?;
-
-        ser.into_inner()
-            .write_all(b"\n")
-            .context("Error writing serialized voter selection to file")
-    }
 }
+
+impl SerializablePretty for BallotPreEncrypted {}
 
 impl PartialEq for BallotPreEncrypted {
     fn eq(&self, other: &Self) -> bool {
@@ -219,16 +210,6 @@ impl BallotPreEncrypted {
         ))
     }
 
-    /// Returns a pretty JSON `String` representation of `BallotPreEncrypted`.
-    /// The final line will end with a newline.
-    pub fn to_json(&self) -> String {
-        // `unwrap()` is justified here because why would JSON serialization fail?
-        #[allow(clippy::unwrap_used)]
-        let mut s = serde_json::to_string_pretty(self).unwrap();
-        s.push('\n');
-        s
-    }
-
     /// Reads `BallotPreEncrypted` from a `std::io::Read`.
     pub fn from_reader(io_read: &mut dyn std::io::Read) -> Result<BallotPreEncrypted> {
         serde_json::from_reader(io_read)
@@ -242,16 +223,6 @@ impl BallotPreEncrypted {
 
         Ok(ballot)
     }
-
-    /// Writes a `BallotPreEncrypted` to a `std::io::Write`.
-    pub fn to_stdiowrite(&self, stdiowrite: &mut dyn std::io::Write) -> Result<()> {
-        let mut ser = serde_json::Serializer::pretty(stdiowrite);
-
-        self.serialize(&mut ser)
-            .context("Error writing pre-encrypted ballot")?;
-
-        ser.into_inner()
-            .write_all(b"\n")
-            .context("Error writing pre-encrypted ballot file")
-    }
 }
+
+impl SerializablePretty for VoterSelection {}


### PR DESCRIPTION
- Maybe we should rename `to_stdiowrite` to `write` (and `to_stdiowrite_canonical` to `write_canonical`). Maybe `to_json_pretty` to `to_json` too?
- I put the traits in `src/serialize.rs`, but I wonder if there's a better place.